### PR TITLE
feat: Implement dark mode toggle

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,5 +27,6 @@
         </div>
       </nav>
     {%- endif -%}
+    <button id="dark-mode-toggle" style="float: right; background: none; border: none; cursor: pointer; font-size: 1.5em;">🌙</button>
   </div>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 
     {%- include footer.html -%}
 
+    <script src="{{ '/assets/js/darkmode.js' | relative_url }}"></script>
   </body>
 
 </html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,6 +2,13 @@
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
 
-@import
-  "minima/skins/{{ site.minima.skin | default: 'classic' }}",
-  "minima/initialize";
+// Import the base styles (variables, mixins, etc.)
+@import "minima/initialize";
+
+// Import the classic skin by default
+@import "minima/skins/classic";
+
+// Import the dark skin styles when the .minima-dark class is present on the body
+body.minima-dark {
+  @import "minima/skins/dark";
+}

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,0 +1,62 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleButton = document.getElementById('dark-mode-toggle');
+  const body = document.body;
+
+  // Function to apply dark mode
+  const enableDarkMode = () => {
+    body.classList.add('dark-mode');
+    localStorage.setItem('darkMode', 'enabled');
+    if (toggleButton) {
+      toggleButton.textContent = '☀️';
+    }
+  };
+
+  // Function to disable dark mode
+  const disableDarkMode = () => {
+    body.classList.remove('dark-mode');
+    localStorage.setItem('darkMode', 'disabled');
+    if (toggleButton) {
+      toggleButton.textContent = '🌙';
+    }
+  };
+
+  // Check for saved preference in localStorage
+  if (localStorage.getItem('darkMode') === 'enabled') {
+    enableDarkMode();
+  } else if (localStorage.getItem('darkMode') === 'disabled') {
+    disableDarkMode();
+  } else {
+    // If no preference, check system preference (optional)
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      enableDarkMode();
+    } else {
+      disableDarkMode(); // Default to light mode if no system preference or not supported
+    }
+  }
+
+  // Add event listener to the toggle button
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      if (body.classList.contains('dark-mode')) {
+        disableDarkMode();
+      } else {
+        enableDarkMode();
+      }
+    });
+  }
+
+  // Listen for changes in system preference (optional)
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+    if (event.matches) {
+      // If user hasn't manually overridden, switch to dark mode
+      if (localStorage.getItem('darkMode') !== 'disabled') {
+        enableDarkMode();
+      }
+    } else {
+      // If user hasn't manually overridden, switch to light mode
+      if (localStorage.getItem('darkMode') !== 'enabled') {
+        disableDarkMode();
+      }
+    }
+  });
+});

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleButton = document.getElementById('dark-mode-toggle');
+  const body = document.body;
+  const darkClassName = 'minima-dark';
+  const sunIcon = '☀️';
+  const moonIcon = '🌙';
+
+  // Function to enable dark mode
+  const enableDarkMode = () => {
+    body.classList.add(darkClassName);
+    if (toggleButton) {
+      toggleButton.textContent = sunIcon;
+    }
+    localStorage.setItem('theme', 'dark');
+  };
+
+  // Function to disable dark mode
+  const disableDarkMode = () => {
+    body.classList.remove(darkClassName);
+    if (toggleButton) {
+      toggleButton.textContent = moonIcon;
+    }
+    localStorage.setItem('theme', 'light');
+  };
+
+  // Check localStorage for saved theme on load
+  const currentTheme = localStorage.getItem('theme');
+  if (currentTheme === 'dark') {
+    enableDarkMode();
+  } else {
+    // Default to light mode if no theme or theme is 'light'
+    disableDarkMode();
+  }
+
+  // Add event listener to the toggle button
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      if (body.classList.contains(darkClassName)) {
+        disableDarkMode();
+      } else {
+        enableDarkMode();
+      }
+    });
+  } else {
+    console.warn('Dark mode toggle button not found.');
+  }
+});


### PR DESCRIPTION
Adds a dark mode feature to the website.

Key changes:
- A toggle button (using 🌙/☀️ icons) has been added to the site header.
- JavaScript (`assets/js/darkmode.js`) handles theme switching:
    - Toggles a `minima-dark` class on the `<body>` element.
    - Saves your theme preference in `localStorage`.
    - Applies the saved theme on page load.
- `assets/css/style.scss` has been updated to:
    - Import Minima's `classic` skin by default.
    - Import Minima's `dark` skin rules when `body.minima-dark` is active.

This allows you to switch between light and dark themes, and your preference will be remembered across sessions.