### PR TITLE
Add dark mode with toggle

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,7 @@
     
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
+  <link id="dark-theme-style" rel="stylesheet" href="{{ "/assets/css/dark.css" | relative_url }}" disabled>
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,5 +27,13 @@
         </div>
       </nav>
     {%- endif -%}
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
+      <svg class="sun-icon" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M10 3a1 1 0 011 1v1a1 1 0 11-2 0V4a1 1 0 011-1zM10 15a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm7-5a1 1 0 110 2h-1a1 1 0 110-2h1zM5 10a1 1 0 100 2H4a1 1 0 100-2h1zM14.657 5.343a1 1 0 010 1.414L14 7.414a1 1 0 01-1.414-1.414l.657-.657a1 1 0 011.414 0zM7.414 14l-.657.657a1 1 0 01-1.414-1.414L6 12.586A1 1 0 017.414 14zM14 12.586l.657.657a1 1 0 01-1.414 1.414L12.586 14A1 1 0 0114 12.586zM6 7.414L5.343 6.757A1 1 0 016.757 5.343L7.414 6A1 1 0 016 7.414zM10 6a4 4 0 100 8 4 4 0 000-8z"/>
+      </svg>
+      <svg class="moon-icon" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M17.293 13.293A8 8 0 116.707 2.707 7 7 0 1017.293 13.293z" clip-rule="evenodd"/>
+      </svg>
+    </button>
   </div>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,7 @@
     </main>
 
     {%- include footer.html -%}
+    <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}"></script>
 
   </body>
 

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,2 +1,47 @@
 // Placeholder to allow defining custom styles that override everything else.
 // (Use `_sass/minima/custom-variables.scss` to override variable defaults)
+
+.theme-toggle {
+  margin-left: auto;
+  border: none;
+  cursor: pointer;
+  width: 2.5rem;
+  height: 1.25rem;
+  background: #e2e8f0;
+  border-radius: 9999px;
+  position: relative;
+  padding: 0;
+  transition: background 0.3s ease;
+}
+
+.theme-toggle svg {
+  width: 0.75rem;
+  height: 0.75rem;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #374151;
+  display: none;
+}
+
+.theme-toggle .sun-icon {
+  left: 0.25rem;
+  color: #f59e0b;
+}
+
+.theme-toggle .moon-icon {
+  right: 0.25rem;
+  display: block;
+}
+
+body.dark .theme-toggle {
+  background: #374151;
+}
+
+body.dark .theme-toggle .sun-icon {
+  display: block;
+}
+
+body.dark .theme-toggle .moon-icon {
+  display: none;
+}

--- a/assets/css/dark.scss
+++ b/assets/css/dark.scss
@@ -1,0 +1,3 @@
+---
+---
+@import "minima/skins/dark", "minima/initialize";

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,27 @@
+(function() {
+  const toggle = document.getElementById('theme-toggle');
+  const darkStyle = document.getElementById('dark-theme-style');
+  if (!toggle || !darkStyle) return;
+
+  function setTheme(theme) {
+    if (theme === 'dark') {
+      darkStyle.disabled = false;
+      document.body.classList.add('dark');
+    } else {
+      darkStyle.disabled = true;
+      document.body.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }
+
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') {
+    setTheme('dark');
+  } else if (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    setTheme('dark');
+  }
+
+  toggle.addEventListener('click', function() {
+    setTheme(darkStyle.disabled ? 'dark' : 'light');
+  });
+})();


### PR DESCRIPTION
## Summary
- add dark skin stylesheet
- provide JS to toggle between light and dark themes
- include theme toggle button in header
- style toggle button
- load toggle script in layout
- polish button styling for a more modern look

## Testing
- `bundle install`
- `script/cibuild`


------
https://chatgpt.com/codex/tasks/task_e_683f830eea64832294ce452e9dfdd69f